### PR TITLE
Create torrent_extensions

### DIFF
--- a/magic/Magdir/torrent_extensions
+++ b/magic/Magdir/torrent_extensions
@@ -1,0 +1,4 @@
+#2015/12/24 Add support for Multitracker Metadata Extension as per http://www.bittorrent.org/beps/bep_0012.html
+#           (Durval Menezes, jmgthbfile@durval.com) 
+0       string  d13:announce-list       BitTorrent file
+!:mime  application/x-bittorrent


### PR DESCRIPTION
Initially adds support for Multitracker Metadata Extension (as per http://www.bittorrent.org/beps/bep_0012.html), in the future all other torrent extensions should be added here.